### PR TITLE
drivedb.h: Adding INTEL DC S3110 support

### DIFF
--- a/drivedb.h
+++ b/drivedb.h
@@ -610,7 +610,7 @@ const drive_settings builtin_knowndrives[] = {
     "-v 192,raw48,Unsafe_Shutdown_Count "
     "-v 160,raw48,Uncorrectable_Error_Cnt "
     // 0729 - remaining in block life. In 0828  remaining is normalized to 100% then decreases
-    "-v 161,raw48,Spares_Remaining " 
+    "-v 161,raw48,Spares_Remaining "
     "-v 241,raw48,Host_Writes_32MiB "
     "-v 242,raw48,Host_Reads_32MiB "
     "-v 169,raw48,Lifetime_Remaining% "
@@ -1268,7 +1268,7 @@ const drive_settings builtin_knowndrives[] = {
   // https://www.intel.com/content/www/us/en/solid-state-drives/ssd-540s-series-spec.html
   // https://www.intel.com/content/www/us/en/solid-state-drives/ssd-540s-series-m2-spec.html
   { "Intel 540 Series SSDs", // INTEL SSDSC2KW120H6/LSF036C, INTEL SSDSC2KW480H6/LSF036C
-    "INTEL SSDSC[K2]KW(120H|180H|240H|360H|480H|010X)6", 
+    "INTEL SSDSC[K2]KW(120H|180H|240H|360H|480H|010X)6",
     "", "",
     "-v 9,msec24hour32,Power_On_Hours_and_Msec "
     "-v 170,raw48,Available_Reservd_Space "
@@ -1366,6 +1366,22 @@ const drive_settings builtin_knowndrives[] = {
     "-v 227,raw48,Workld_Host_Reads_Perc "
     "-v 228,raw48,Workload_Minutes "
     "-v 249,raw48,NAND_Writes_1GiB "
+  },
+  { "Intel DC S3110 Series SSDs", // Tested with INTEL SSDSCKKI256G8
+    "INTEL SSDSCKKI(128|256|512)G8",
+    "", "",
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 183,raw48,SATA_Downshift_Count "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes "
+    "-v 241,raw48,Total_LBAs_Written "
+    "-v 249,raw48,NAND_Writes_1GiB"
   },
   { "Intel 3710 Series SSDs", // INTEL SSDSC2BA200G4R/G201DL2B (dell)
     "INTEL SSDSC2BA(200G|400G|800G|012T)4.?",
@@ -2425,7 +2441,7 @@ const drive_settings builtin_knowndrives[] = {
   },
   // Flash accelerated, no SMART info in the specs
   // ST1000LX015-1U7172/SDM1
-  { "Seagate FireCuda 2.5", // 
+  { "Seagate FireCuda 2.5", //
     "ST(500|1000|2000)LX0(01|15|25)-.*",
     "", "", "-v 240,msec24hour32 "
   },
@@ -3354,7 +3370,7 @@ const drive_settings builtin_knowndrives[] = {
   },
   { "Toshiba HK4R Series SSD", // TOSHIBA THNSN8960PCSE/8EET6101
     "TOSHIBA THNSN8(120P|240P|480P|960P|1Q92)CSE",
-    "", "", 
+    "", "",
     "-v 167,raw48,SSD_Protect_Mode "
     "-v 168,raw48,SATA_PHY_Error_Count "
     "-v 169,raw48,Bad_Block_Count "
@@ -3365,7 +3381,7 @@ const drive_settings builtin_knowndrives[] = {
     // TOSHIBA THNSFJ256GCSU/JULA1102
     // TOSHIBA THNSFJ256GDNU A/JYLA1102
     "TOSHIBA THNS[NF]J(060|128|256|512)G[BCAM8VD][SCN][TU].*",
-    "", "", 
+    "", "",
     "-v 167,raw48,SSD_Protect_Mode "
     "-v 168,raw48,SATA_PHY_Error_Count "
     "-v 169,raw48,Bad_Block_Count "
@@ -3821,7 +3837,7 @@ const drive_settings builtin_knowndrives[] = {
       // ST1000NM0055-1V410C/TN02
       // ST8000NM0055-1RM112/SN04
     "ST([1234568]|10)000NM0[01][0-68][456]-.*", // *[069]4 = 4Kn
-    "", "", 
+    "", "",
     "-v 188,raw16 -v 240,msec24hour32"
   },
   { "Seagate Enterprise Capacity 3.5 HDD", // V5.1, ms in attribute 9
@@ -3936,7 +3952,7 @@ const drive_settings builtin_knowndrives[] = {
   },
   { "Seagate Nytro XF1230 SATA SSD", // tested with XF1230-1A0480/ST200354
     "XF1230-1A(0240|0480|0960|1920)",
-    "", "", 
+    "", "",
     "-v 174,raw48,Unexpect_Power_Loss_Ct "
     "-v 180,raw48,End_to_End_Err_Detect "
     "-v 183,raw48,SATA_Downshift_Count "
@@ -4032,8 +4048,8 @@ const drive_settings builtin_knowndrives[] = {
   //"-v 184,raw48,End-to-end_Error " // Detection/Correction Count
   //"-v 187,raw48,Reported_Uncorrect " // Uncorrectable Errors
   //"-v 188,raw48,Command_Timeout
-  //"-v 194,tempminmax,Temperature_Celsius " 
-  //"-v 199,raw48,UDMA_CRC_Error_Count  // SATA CRC Errors 
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 199,raw48,UDMA_CRC_Error_Count  // SATA CRC Errors
     "-v 230,hex48,Media_Wearout_Indicator " // Maybe hex16
   //"-v 232,raw48,Available_Reserve_Space"
     "-v 233,raw48,NAND_GB_Written_TLC "


### PR DESCRIPTION
This SSD family wasn't managed by the actual code.
As per the isdct intel tool output, let's name the reported fields.

Signed-off-by: Erwan Velu <e.velu@criteo.com>